### PR TITLE
Update image versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DOCKERFILE_PATH		:= $(CURDIR)/docker
 
 USERNAME		:= $(USER)
 GIT_COMMIT 		:= $(shell git describe --dirty=-unsupported --always || echo pre-commit)
-IMAGE_VERSION		?= v1.0
+IMAGE_VERSION		?= v1.1
 
 SERVER_BINARY 		:= $(BUILD_PATH)/server
 SERVER_PATH 		:= $(PROJECT_ROOT)/cmd/server
@@ -93,12 +93,12 @@ vendor-update:
 
 .PHONY: image
 image:
-	docker build -f docker/Dockerfile.contacts-server -t infoblox/contacts-server:v1.0 .
-	docker build -f docker/Dockerfile.contacts-gateway -t infoblox/contacts-gateway:v1.0 .
+	docker build -f docker/Dockerfile.contacts-server -t infoblox/contacts-server:$(IMAGE_VERSION) .
+	docker build -f docker/Dockerfile.contacts-gateway -t infoblox/contacts-gateway:$(IMAGE_VERSION) .
 
 .PHONY: image-clean
 image-clean:
-	docker rmi -f infoblox/contacts-server:v1.0 infoblox/contacts-gateway:v1.0
+	docker rmi -f infoblox/contacts-server:$(IMAGE_VERSION) infoblox/contacts-gateway:$(IMAGE_VERSION)
 
 .PHONY: up
 up:

--- a/kube/kube.yaml
+++ b/kube/kube.yaml
@@ -54,7 +54,7 @@ spec:
         - "-shealth"
         - "0.0.0.0:8089"
         image: infoblox/contacts-gateway:latest
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         ports:
         - containerPort: 8080
         livenessProbe:
@@ -85,7 +85,7 @@ spec:
         # requests to the contacts-app
         # - "-authz=pdpserver.authz:5555"
         image: infoblox/contacts-server:latest
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         ports:
         - containerPort: 9091
           protocol: TCP
@@ -146,7 +146,7 @@ spec:
       containers:
       - name: postgres
         image: postgres:9.4
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         env:
         - name: POSTGRES_USER
           value: postgres

--- a/kube/kube.yaml
+++ b/kube/kube.yaml
@@ -53,7 +53,7 @@ spec:
         - "0.0.0.0:8088"
         - "-shealth"
         - "0.0.0.0:8089"
-        image: infoblox/contacts-gateway:v1.0
+        image: infoblox/contacts-gateway:latest
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -84,7 +84,7 @@ spec:
         # note that authz also needs to be running in order to authorize
         # requests to the contacts-app
         # - "-authz=pdpserver.authz:5555"
-        image: infoblox/contacts-server:v1.0
+        image: infoblox/contacts-server:latest
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091


### PR DESCRIPTION
# Update Image Versions

These changes are pretty minimal, but here's a quick summary.

- **Build the latest image versions:** there's a new version of the `atlas-contacts-app` gateway and server available on the [infoblox Docker registry](https://hub.docker.com/r/infoblox/contacts-gateway/tags/), so I updated the Makefile to target these new versions.

- **Pull latest images:** I updated the Manifest to pull `latest` versions for the gateway and server.

- **Updated  image pull policies:** If possible, I think it's best to avoid using `IfNotPresent` because it requires manually pulling new images versions. If we push fixes to the contacts application, these changes should get introduced automatically whenever someone runs `make up`