### PR TITLE
Update Image Pull Policies

### DIFF
--- a/deploy/kube.yaml
+++ b/deploy/kube.yaml
@@ -146,7 +146,6 @@ spec:
       containers:
       - name: postgres
         image: postgres:9.4
-        imagePullPolicy: IfNotPresent
         env:
         - name: POSTGRES_USER
           value: postgres

--- a/deploy/kube.yaml
+++ b/deploy/kube.yaml
@@ -54,7 +54,7 @@ spec:
         - "-shealth"
         - "0.0.0.0:8089"
         image: infoblox/contacts-gateway:latest
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         ports:
         - containerPort: 8080
         livenessProbe:
@@ -85,7 +85,7 @@ spec:
         # requests to the contacts-app
         # - "-authz=pdpserver.authz:5555"
         image: infoblox/contacts-server:latest
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         ports:
         - containerPort: 9091
           protocol: TCP


### PR DESCRIPTION
# Update Image Pull Policies

This pull request changes the image pull policies to `Always` for the server and gateway images. This way, when someone (e.g. the people testing the contacts application) runs `make up`, they are guaranteed to have the most recent images.

The default image pull policy is `ifNotPresent` by default, so I removed this field from the Postgres deployment to avoid redundancy.