### PR TITLE
Add flag to set log-level across application

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -27,6 +27,7 @@ var (
 	HealthAddress      string
 	DBConnectionString string
 	AuthzAddr          string
+	LogLevel           string
 )
 
 const (
@@ -37,7 +38,24 @@ const (
 )
 
 func main() {
-	logger := logrus.New()
+	logger := logrus.StandardLogger()
+
+	// Set the log level on the default logger based on command line flag
+	logLevels := map[string]logrus.Level{
+		"debug":   logrus.DebugLevel,
+		"info":    logrus.InfoLevel,
+		"warning": logrus.WarnLevel,
+		"error":   logrus.ErrorLevel,
+		"fatal":   logrus.FatalLevel,
+		"panic":   logrus.PanicLevel,
+	}
+	if level, ok := logLevels[LogLevel]; !ok {
+		logger.Errorf("Invalid value %q provided for log level", LogLevel)
+		logger.SetLevel(logrus.InfoLevel)
+	} else {
+		logger.SetLevel(level)
+	}
+
 	// create new tcp listenerf
 	ln, err := net.Listen("tcp", ServerAddress)
 	if err != nil {
@@ -130,6 +148,7 @@ func init() {
 	flag.StringVar(&DBConnectionString, "db", "", "the database address")
 	flag.StringVar(&HealthAddress, "health", "0.0.0.0:8089", "Address for health checking")
 	flag.StringVar(&AuthzAddr, "authz", "", "address of the authorization service")
+	flag.StringVar(&LogLevel, "log", "info", "log level")
 	flag.Parse()
 }
 

--- a/deploy/kube.yaml
+++ b/deploy/kube.yaml
@@ -51,7 +51,7 @@ spec:
     spec:
       containers:
       - name: gateway
-        args: 
+        args:
         - "-health"
         - "0.0.0.0:8088"
         - "-shealth"
@@ -83,6 +83,8 @@ spec:
         - "host=postgres port=5432 user=postgres password=postgres sslmode=disable dbname=contacts"
         - "-health"
         - "0.0.0.0:8089"
+        - "-log"
+        - "debug"
         # uncomment to add authorization to the contacts-app example. Please
         # note that authz also needs to be running in order to authorize
         # requests to the contacts-app
@@ -182,4 +184,3 @@ spec:
             - "-i"
             - "-c"
             - "psql -h 127.0.0.1 -U $POSTGRES_USER -q -d $POSTGRES_PASSWORD -c 'SELECT 1'"
-            


### PR DESCRIPTION
Rudimentary support for custom log-level. 
Application wide, no run-time alteration or per-request behavior. 