### PR TITLE
Fix docker image name and update imagePullPolicy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ IMAGE_REGISTRY ?= infoblox
 # configuration for server binary and image
 SERVER_BINARY     := $(BUILD_PATH)/server
 SERVER_PATH       := $(PROJECT_ROOT)/cmd/server
-SERVER_IMAGE      := $(IMAGE_REGISTRY)/atlas-contacts-app-server
+SERVER_IMAGE      := $(IMAGE_REGISTRY)/contacts-server
 SERVER_DOCKERFILE := $(DOCKERFILE_PATH)/Dockerfile
 
 # configuration for the protobuf gentool

--- a/deploy/kube.yaml
+++ b/deploy/kube.yaml
@@ -62,7 +62,7 @@ spec:
         # requests to the contacts-app
         # - "-authz=pdpserver.authz:5555"
         image: infoblox/contacts-server:latest
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         ports:
         - containerPort: 8080
           protocol: TCP

--- a/deploy/kube.yaml
+++ b/deploy/kube.yaml
@@ -61,7 +61,7 @@ spec:
         # note that authz also needs to be running in order to authorize
         # requests to the contacts-app
         # - "-authz=pdpserver.authz:5555"
-        image: infoblox/atlas-contacts-app-server:latest
+        image: infoblox/contacts-server:latest
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080


### PR DESCRIPTION
# Fix Deployment Problems

- **Docker image bug** — The `Makefile` and `kube.yaml` currently point to the wrong Docker registry. This pull request fixes that issue.
- **Change imagePullPolicy** — When users deploy the contacts application, Kubernetes should always pull the most up-to-date image.