### PR TITLE
Add gateway integration tests (WIP)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,12 @@
 
 
 [[projects]]
+  name = "github.com/bitly/go-simplejson"
+  packages = ["."]
+  revision = "aabad6e819789e569bd6aabf444c935aa9ba1e44"
+  version = "v0.5.0"
+
+[[projects]]
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
   revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
@@ -276,6 +282,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "26784b2fdffa99197ffad8ace3f07dd17c042c0e4b7cde5b83fe3d5882a4b7d1"
+  inputs-digest = "46a217f282f015344eb423e40301f3654f1be314fc5ac7d177924db75255dde6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -11,4 +11,8 @@ const (
 	DBConnectionString = "host=localhost port=5432 user=postgres password=postgres sslmode=disable dbname=atlas_contacts_app"
 	// SwaggerFile is the file location of the swagger file to serve
 	SwaggerFile = "./pkg/pb/contacts.swagger.json"
+	// ApplicationID associates a microservice with an application. The atlas
+	// contacts application consists of only one service, so we identify both the
+	// service and the application as "atlas-contacts-app"
+	ApplicationID = "atlas-contacts-app"
 )

--- a/cmd/server/grpc.go
+++ b/cmd/server/grpc.go
@@ -7,6 +7,7 @@ import (
 	toolkit_auth "github.com/infobloxopen/atlas-app-toolkit/auth"
 	"github.com/infobloxopen/atlas-app-toolkit/gateway"
 	"github.com/infobloxopen/atlas-app-toolkit/requestid"
+	"github.com/infobloxopen/atlas-contacts-app/cmd"
 	"github.com/infobloxopen/atlas-contacts-app/pkg/pb"
 	"github.com/infobloxopen/atlas-contacts-app/pkg/svc"
 	"github.com/jinzhu/gorm"
@@ -26,7 +27,7 @@ func NewGRPCServer(logger *logrus.Logger, db *gorm.DB) (*grpc.Server, error) {
 	// add authorization interceptor if authz service address is provided
 	if AuthzAddr != "" {
 		// authorization interceptor
-		interceptors = append(interceptors, toolkit_auth.UnaryServerInterceptor(AuthzAddr, applicationID))
+		interceptors = append(interceptors, toolkit_auth.UnaryServerInterceptor(AuthzAddr, cmd.ApplicationID))
 	}
 
 	// create new gRPC grpcServer with middleware chain

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -33,13 +33,6 @@ var (
 	LogLevel           string
 )
 
-const (
-	// applicationID associates a microservice with an application. the atlas
-	// contacts application consists of only one service, so we identify both the
-	// service and the application as "contacts"
-	applicationID = "contacts"
-)
-
 func main() {
 	doneC := make(chan error)
 	logger := NewLogger()
@@ -62,7 +55,7 @@ func init() {
 	flag.StringVar(&AuthzAddr, "authz", "", "address of the authorization service")
 	flag.StringVar(&LogLevel, "log", "info", "log level")
 	flag.Parse()
-	resource.RegisterApplication("atlas-contacts-app")
+	resource.RegisterApplication(cmd.ApplicationID)
 }
 
 func NewLogger() *logrus.Logger {

--- a/integration/http_test.go
+++ b/integration/http_test.go
@@ -1,0 +1,273 @@
+// +build integration
+
+package integration
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/bitly/go-simplejson"
+	"github.com/infobloxopen/atlas-contacts-app/pkg/pb"
+)
+
+// TestCreateContact_REST uses the REST gateway to create a new contact and
+// ensure the JSON response matches what is expected
+// 1. Create a contact entry with a POST request
+// 2. Unmarshal the JSON into a simplejson struct
+// 3. Ensure the JSON fields match what is expected
+func TestCreateContact_REST(t *testing.T) {
+	dbTest.Reset(t)
+	contact := pb.Contact{
+		FirstName:    "Steven",
+		MiddleName:   "James",
+		LastName:     "McKubernetes",
+		PrimaryEmail: "test@test.com",
+		Notes:        "set sail at sunrise",
+	}
+	res, err := MakeRequestWithDefaults(
+		http.MethodPost,
+		"http://localhost:8080/atlas-contacts-app/v1/contacts",
+		contact,
+	)
+	if err != nil {
+		t.Fatalf("unable to create contact: %v", err)
+	}
+	ValidateResponseCode(t, res, http.StatusOK)
+	responseJSON, err := simplejson.NewFromReader(res.Body)
+	if err != nil {
+		t.Fatalf("unable to marshal json response: %v", err)
+	}
+	var tests = []struct {
+		name   string
+		json   *simplejson.Json
+		expect string
+	}{
+		{
+			name:   "contact first name",
+			json:   responseJSON.GetPath("result", "first_name"),
+			expect: `"Steven"`,
+		},
+		{
+			name:   "contact middle name",
+			json:   responseJSON.GetPath("result", "middle_name"),
+			expect: `"James"`,
+		},
+		{
+			name:   "contact last",
+			json:   responseJSON.GetPath("result", "last_name"),
+			expect: `"McKubernetes"`,
+		},
+		{
+			name:   "contact notes",
+			json:   responseJSON.GetPath("result", "notes"),
+			expect: `"set sail at sunrise"`,
+		},
+		{
+			name:   "contact primary email",
+			json:   responseJSON.GetPath("result", "primary_email"),
+			expect: `"test@test.com"`,
+		},
+		{
+			name:   "contact email list",
+			json:   responseJSON.GetPath("result", "emails"),
+			expect: `[{"address":"test@test.com","id":"1"}]`,
+		},
+		{
+			name:   "success response",
+			json:   responseJSON.GetPath("success"),
+			expect: `{"code":"OK","status":200}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ValidateJSONSchema(t, test.json, test.expect)
+		})
+	}
+}
+
+// TestReadContact_REST uses the REST gateway to create a new contact and
+// then read that contact from the application
+// 1. Create a contact entry with a POST request
+// 2. Get the contact from the applicaiton
+// 2. Unmarshal the JSON into a simplejson struct
+// 3. Ensure the JSON fields match what is expected
+func TestReadContact_REST(t *testing.T) {
+	dbTest.Reset(t)
+	contact := pb.Contact{
+		FirstName:    "Wilfred",
+		MiddleName:   "Wallace",
+		LastName:     "O'Docker",
+		PrimaryEmail: "test@test.com",
+		Notes:        "build the containers at dusk",
+	}
+	_, err := MakeRequestWithDefaults(
+		http.MethodPost, "http://localhost:8080/atlas-contacts-app/v1/contacts",
+		contact,
+	)
+	if err != nil {
+		t.Fatalf("unable to create contact: %v", err)
+	}
+	res, err := MakeRequestWithDefaults(
+		http.MethodGet, "http://localhost:8080/atlas-contacts-app/v1/contacts/1",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("unable to get contact: %v", err)
+	}
+	ValidateResponseCode(t, res, http.StatusOK)
+	responseJSON, err := simplejson.NewFromReader(res.Body)
+	var tests = []struct {
+		name   string
+		json   *simplejson.Json
+		expect string
+	}{
+		{
+			name:   "contact first name",
+			json:   responseJSON.GetPath("result", "first_name"),
+			expect: `"Wilfred"`,
+		},
+		{
+			name:   "contact middle name",
+			json:   responseJSON.GetPath("result", "middle_name"),
+			expect: `"Wallace"`,
+		},
+		{
+			name:   "contact last",
+			json:   responseJSON.GetPath("result", "last_name"),
+			expect: `"O'Docker"`,
+		},
+		{
+			name:   "contact notes",
+			json:   responseJSON.GetPath("result", "notes"),
+			expect: `"build the containers at dusk"`,
+		},
+		{
+			name:   "contact primary email",
+			json:   responseJSON.GetPath("result", "primary_email"),
+			expect: `"test@test.com"`,
+		},
+		{
+			name:   "contact email list",
+			json:   responseJSON.GetPath("result", "emails"),
+			expect: `[{"address":"test@test.com","id":"1"}]`,
+		},
+		{
+			name:   "success response",
+			json:   responseJSON.GetPath("success"),
+			expect: `{"code":"OK","status":200}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ValidateJSONSchema(t, test.json, test.expect)
+		})
+	}
+}
+
+// TestInvalidEmail_REST attempts to create a new contact that has an invalid
+// email address.
+// 1. Use the REST API to create a new contact with an invalid email
+// 2. Ensure the HTTP response status code is 400
+// 3. Ensure the HTTP response has a detailed error message
+func TestInvalidEmail_REST(t *testing.T) {
+	dbTest.Reset(t)
+	contact := pb.Contact{
+		PrimaryEmail: "invalid-email-address",
+	}
+	res, err := MakeRequestWithDefaults(
+		http.MethodPost, "http://localhost:8080/atlas-contacts-app/v1/contacts",
+		contact,
+	)
+	if err != nil {
+		t.Fatalf("unable to create contact %v", err)
+	}
+	ValidateResponseCode(t, res, http.StatusBadRequest)
+	responseJSON, err := simplejson.NewFromReader(res.Body)
+	if err != nil {
+		t.Fatalf("unable to unmarshal response json: %v", err)
+	}
+	var tests = []struct {
+		name   string
+		json   *simplejson.Json
+		expect string
+	}{
+		{
+			name:   "check response code",
+			json:   responseJSON.GetPath("error", "code"),
+			expect: `"INVALID_ARGUMENT"`,
+		},
+		{
+			name:   "check http status",
+			json:   responseJSON.GetPath("error", "status"),
+			expect: `400`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ValidateJSONSchema(t, test.json, test.expect)
+		})
+	}
+}
+
+// TestDeleteContact_REST uses the REST gateway to create a new contact and
+// ensure it can get deleted correctly
+// 1. Create a contact entry with a POST request
+// 2. Delete the contact
+// 3. Ensure the DELETE response matches schema is expected
+func TestDeleteContact_REST(t *testing.T) {
+	dbTest.Reset(t)
+	contact := pb.Contact{
+		PrimaryEmail: "test@test.com",
+	}
+	_, err := MakeRequestWithDefaults(
+		http.MethodPost,
+		"http://localhost:8080/atlas-contacts-app/v1/contacts",
+		contact,
+	)
+	if err != nil {
+		t.Fatalf("unable to create contact: %v", err)
+	}
+	res, err := MakeRequestWithDefaults(
+		http.MethodDelete,
+		"http://localhost:8080/atlas-contacts-app/v1/contacts/1",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("unable to delete contact: %v", err)
+	}
+	ValidateResponseCode(t, res, http.StatusOK)
+	jsonResponse, err := simplejson.NewFromReader(res.Body)
+	if err != nil {
+		t.Fatalf("unable to marshal json response: %v", err)
+	}
+	t.Run("success response", func(t *testing.T) {
+		ValidateJSONSchema(t, jsonResponse, `{"success":{"code":"OK","status":200}}`)
+	})
+}
+
+// ValidateResponseCode checks the http status of a given request and will
+// fail the current test if it doesn't match the expected status code
+func ValidateResponseCode(t *testing.T, res *http.Response, expected int) {
+	if expected != res.StatusCode {
+		t.Errorf("validation error: unexpected http response status: have %d; want %d",
+			res.StatusCode, expected,
+		)
+	}
+}
+
+// ValidateJSONSchema ensures a given json field matches an expcted json
+// string
+func ValidateJSONSchema(t *testing.T, json *simplejson.Json, expected string) {
+	if json == nil {
+		t.Fatalf("validation error: json schema for is nil")
+	}
+	encoded, err := json.Encode()
+	if err != nil {
+		t.Fatalf("validation error: unable to encode expected json: %v", err)
+	}
+	if actual := string(encoded); actual != expected {
+		t.Errorf("actual json schema does not match expected schema: have %s; want %v",
+			actual, expected,
+		)
+	}
+}

--- a/integration/http_test.go
+++ b/integration/http_test.go
@@ -26,7 +26,7 @@ func TestCreateContact_REST(t *testing.T) {
 	}
 	res, err := MakeRequestWithDefaults(
 		http.MethodPost,
-		"http://localhost:8080/atlas-contacts-app/v1/contacts",
+		"http://localhost:8080/v1/contacts",
 		contact,
 	)
 	if err != nil {
@@ -101,14 +101,14 @@ func TestReadContact_REST(t *testing.T) {
 		Notes:        "build the containers at dusk",
 	}
 	_, err := MakeRequestWithDefaults(
-		http.MethodPost, "http://localhost:8080/atlas-contacts-app/v1/contacts",
+		http.MethodPost, "http://localhost:8080/v1/contacts",
 		contact,
 	)
 	if err != nil {
 		t.Fatalf("unable to create contact: %v", err)
 	}
 	res, err := MakeRequestWithDefaults(
-		http.MethodGet, "http://localhost:8080/atlas-contacts-app/v1/contacts/1",
+		http.MethodGet, "http://localhost:8080/v1/contacts/1",
 		nil,
 	)
 	if err != nil {
@@ -175,7 +175,7 @@ func TestInvalidEmail_REST(t *testing.T) {
 		PrimaryEmail: "invalid-email-address",
 	}
 	res, err := MakeRequestWithDefaults(
-		http.MethodPost, "http://localhost:8080/atlas-contacts-app/v1/contacts",
+		http.MethodPost, "http://localhost:8080/v1/contacts",
 		contact,
 	)
 	if err != nil {
@@ -221,7 +221,7 @@ func TestDeleteContact_REST(t *testing.T) {
 	}
 	_, err := MakeRequestWithDefaults(
 		http.MethodPost,
-		"http://localhost:8080/atlas-contacts-app/v1/contacts",
+		"http://localhost:8080/v1/contacts",
 		contact,
 	)
 	if err != nil {
@@ -229,7 +229,7 @@ func TestDeleteContact_REST(t *testing.T) {
 	}
 	res, err := MakeRequestWithDefaults(
 		http.MethodDelete,
-		"http://localhost:8080/atlas-contacts-app/v1/contacts/1",
+		"http://localhost:8080/v1/contacts/1",
 		nil,
 	)
 	if err != nil {

--- a/integration/jwt.go
+++ b/integration/jwt.go
@@ -1,8 +1,12 @@
 package integration
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"log"
+	"net/http"
 	"testing"
 
 	jwt "github.com/dgrijalva/jwt-go"
@@ -14,11 +18,14 @@ const (
 	TestSecret = "some-secret-123"
 )
 
+var (
+	// DefaultClaims is the standard payload inside a test JWT
+	DefaultClaims = jwt.MapClaims{"AccountID": "TestAccount"}
+)
+
 // DefaultContext returns a context that has a jwt for basic testing purposes
 func DefaultContext(t *testing.T) context.Context {
-	token, err := MakeToken(jwt.MapClaims{
-		"AccountID": "TestAccount",
-	})
+	token, err := MakeToken(DefaultClaims)
 	if err != nil {
 		t.Fatalf("unable to create default context: %v", err)
 	}
@@ -48,4 +55,35 @@ func MakeToken(claims jwt.Claims) (string, error) {
 		return "", err
 	}
 	return fmt.Sprintf("%s.%s", signingString, signature), nil
+}
+
+// AddDefaultTokenToRequest adds the default authorization token to the http
+// header of a given http request
+func AddDefaultTokenToRequest(req *http.Request) {
+	token, err := MakeToken(DefaultClaims)
+	if err != nil {
+		log.Fatalf("unable to create token")
+	}
+	AddTokenToRequest("token", token, req)
+}
+
+// AddTokenToRequest adds an authorization token to the http request header
+func AddTokenToRequest(key, token string, req *http.Request) {
+	req.Header.Set("Authorization", fmt.Sprintf("%s %s", key, token))
+}
+
+// MakeRequestWithDefaults issues request that contains the necessary parameters
+// request to reach the contacts application (e.g. an authorization token)
+func MakeRequestWithDefaults(method, url string, payload interface{}) (*http.Response, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest(method, url, bytes.NewBuffer(body))
+	AddDefaultTokenToRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	client := http.Client{}
+	return client.Do(req)
 }


### PR DESCRIPTION
# Gateway Integration Tests

This pull requests adds more integration tests to the contacts application, specifically for the gRPC gateway.

**Basic Pattern**
1. Make a request to the contacts application
2. Marshal the response body into a _simplejson_ type
3. Verify, field-by-field, that the response JSON matches the expected JSON


The [simplejson](https://github.com/bitly/go-simplejson) library helps parse arbitrary JSON. In our case, we don't actually have arbitrary response JSON (because we know what contacts application responses look like), but this approach will help us identifiy when breaking changes are made to the API. If we re-use the same struct to marshal JSON _to_ the contacts application and unmarshal JSON _from_ the contacts application, then breaking changes might slip through the cracks.

This pull request is still a WIP (feel free to review, though), but I'll be on PTO next week and wanted to push this before leaving.