### PR TITLE
Fixes for error mapping related functionality

### DIFF
--- a/cmd/server/grpc.go
+++ b/cmd/server/grpc.go
@@ -2,12 +2,9 @@ package main
 
 import (
 	"github.com/grpc-ecosystem/go-grpc-middleware"
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
 	"github.com/grpc-ecosystem/go-grpc-middleware/validator"
 	toolkit_auth "github.com/infobloxopen/atlas-app-toolkit/auth"
-	"github.com/infobloxopen/atlas-app-toolkit/errors"
 	"github.com/infobloxopen/atlas-app-toolkit/gateway"
-	"github.com/infobloxopen/atlas-app-toolkit/requestid"
 	"github.com/infobloxopen/atlas-contacts-app/cmd"
 	"github.com/infobloxopen/atlas-contacts-app/pkg/pb"
 	"github.com/infobloxopen/atlas-contacts-app/pkg/svc"
@@ -15,16 +12,19 @@ import (
 	_ "github.com/jinzhu/gorm/dialects/postgres"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+	"github.com/infobloxopen/atlas-app-toolkit/requestid"
+	"github.com/infobloxopen/atlas-app-toolkit/errors"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
 )
 
 func NewGRPCServer(logger *logrus.Logger, db *gorm.DB) (*grpc.Server, error) {
 	interceptors := []grpc.UnaryServerInterceptor{
+		grpc_logrus.UnaryServerInterceptor(logrus.NewEntry(logger)),
+		requestid.UnaryServerInterceptor(),
+		errors.UnaryServerInterceptor(ErrorMappings...),
 		// validation interceptor
 		grpc_validator.UnaryServerInterceptor(),
-		grpc_logrus.UnaryServerInterceptor(logrus.NewEntry(logger)),
-		errors.UnaryServerInterceptor(ErrorMappings...),
 		gateway.UnaryServerInterceptor(),
-		requestid.UnaryServerInterceptor(),
 	}
 	// add authorization interceptor if authz service address is provided
 	if AuthzAddr != "" {

--- a/pkg/pb/contacts.override.gorm.go
+++ b/pkg/pb/contacts.override.gorm.go
@@ -48,9 +48,13 @@ func (m *ContactORM) AfterToPB(ctx context.Context, c *Contact) error {
 func (m *ContactsDefaultServer) CustomRead(ctx context.Context, req *ReadContactRequest) (*ReadContactResponse, error) {
 	res, err := DefaultReadContact(ctx, &Contact{Id: req.GetId()}, m.DB)
 	if err != nil {
-		st := status.Newf(codes.Internal, "Unable to read contact. Error %v", err)
-		st, _ = st.WithDetails(errdetails.New(codes.Internal, "CustomRead", "Custom error message"))
-		st, _ = st.WithDetails(errdetails.New(codes.Internal, "CustomRead", "Another custom error message"))
+		code := codes.Internal
+		if (err == gorm.ErrRecordNotFound) {
+			code = codes.NotFound
+		}
+		st := status.Newf(code, "Unable to read contact. Error %v", err)
+		st, _ = st.WithDetails(errdetails.New(codes.InvalidArgument, "CustomRead", "Example of custom error message"))
+		st, _ = st.WithDetails(errdetails.New(codes.InvalidArgument, "CustomRead", "Another example of custom error message"))
 		return nil, st.Err()
 	}
 	return &ReadContactResponse{Result: res}, nil

--- a/pkg/pb/contacts.override.gorm.go
+++ b/pkg/pb/contacts.override.gorm.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/infobloxopen/atlas-app-toolkit/query"
 	"github.com/infobloxopen/atlas-app-toolkit/rpc/errdetails"
+	"github.com/jinzhu/gorm"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -49,7 +50,7 @@ func (m *ContactsDefaultServer) CustomRead(ctx context.Context, req *ReadContact
 	res, err := DefaultReadContact(ctx, &Contact{Id: req.GetId()}, m.DB)
 	if err != nil {
 		code := codes.Internal
-		if (err == gorm.ErrRecordNotFound) {
+		if err == gorm.ErrRecordNotFound {
 			code = codes.NotFound
 		}
 		st := status.Newf(code, "Unable to read contact. Error %v", err)


### PR DESCRIPTION
Fix "GET operation on a non existing ID shouldn't return error 500"
Improved default internal error mapping (hide original error, display Request-ID)
Proper ordering for interceptors